### PR TITLE
Add multisig mock helper

### DIFF
--- a/Sources/BitcoinKit/Mock/MockHelper.swift
+++ b/Sources/BitcoinKit/Mock/MockHelper.swift
@@ -79,12 +79,13 @@ public struct MockHelper {
                            lockTime: tx.lockTime)
     }
 
-    public static func verifySingleKey(lockScript: Script, unlockScriptBuilder: SingleKeyScriptBuilder, hashType: SighashType, key: MockKey) throws -> Bool {
+    public static func verifySingleKey(lockScript: Script, unlockScriptBuilder: SingleKeyScriptBuilder, key: MockKey) throws -> Bool {
         // mocks
         let utxoMock: UnspentTransaction = MockHelper.createUtxo(lockScript: lockScript)
         let txMock: Transaction = MockHelper.createTransaction(utxo: utxoMock)
 
         // signature, unlockScript(scriptSig)
+        let hashType = SighashType.BCH.ALL
         let signature: Data = key.privkey.sign(txMock, utxoToSign: utxoMock, hashType: hashType)
         let sigWithHashType: Data = signature + UInt8(hashType)
         let unlockScript: Script = unlockScriptBuilder(sigWithHashType, key)
@@ -100,12 +101,13 @@ public struct MockHelper {
         return try ScriptMachine.verify(lockScript: lockScript, unlockScript: unlockScript, context: context)
     }
 
-    public static func verifyMultiKey(lockScript: Script, unlockScriptBuilder: MultiKeyScriptBuilder, hashType: SighashType, keys: [MockKey]) throws -> Bool {
+    public static func verifyMultiKey(lockScript: Script, unlockScriptBuilder: MultiKeyScriptBuilder, keys: [MockKey]) throws -> Bool {
         // mocks
         let utxoMock: UnspentTransaction = MockHelper.createUtxo(lockScript: lockScript)
         let txMock: Transaction = MockHelper.createTransaction(utxo: utxoMock)
 
         // signature, unlockScript(scriptSig)
+        let hashType = SighashType.BCH.ALL
         var sigKeyPairs: [SigKeyPair] = []
         for key in keys {
             let signature: Data = key.privkey.sign(txMock, utxoToSign: utxoMock, hashType: hashType)

--- a/Sources/BitcoinKit/Mock/MockHelper.swift
+++ b/Sources/BitcoinKit/Mock/MockHelper.swift
@@ -26,7 +26,7 @@ import Foundation
 
 public typealias SigKeyPair = (sig: Data, key: MockKey)
 
-public typealias SingleKeyScriptBuilder = ((Data, MockKey) -> Script)
+public typealias SingleKeyScriptBuilder = ((SigKeyPair) -> Script)
 public typealias MultiKeyScriptBuilder = (([SigKeyPair]) -> Script)
 
 public struct MockHelper {
@@ -88,7 +88,7 @@ public struct MockHelper {
         let hashType = SighashType.BCH.ALL
         let signature: Data = key.privkey.sign(txMock, utxoToSign: utxoMock, hashType: hashType)
         let sigWithHashType: Data = signature + UInt8(hashType)
-        let unlockScript: Script = unlockScriptBuilder(sigWithHashType, key)
+        let unlockScript: Script = unlockScriptBuilder((sigWithHashType, key))
 
         // signed tx
         let signedTxMock = MockHelper.updateTransaction(txMock, unlockScriptData: unlockScript.data)

--- a/Tests/BitcoinKitTests/MockHelperTests.swift
+++ b/Tests/BitcoinKitTests/MockHelperTests.swift
@@ -59,7 +59,6 @@ class MockHelperTests: XCTestCase {
                 XCTAssertFalse(result, "P2SHMultisig: \(key) Should fail but succeeds.")
             } catch {
                 // Expected fail:  do nothing
-                // print(error)
             }
         }
         
@@ -106,7 +105,6 @@ class MockHelperTests: XCTestCase {
                 XCTAssertFalse(result, "P2SHMultisig: \(key) Should fail but succeeds.")
             } catch {
                 // Expected fail:  do nothing
-                // print(error)
             }
         }
         
@@ -192,7 +190,6 @@ class MockHelperTests: XCTestCase {
                 XCTAssertFalse(result, "CustomMultisig: \(key) Should fail but succeeds.")
             } catch {
                 // Expected fail:  do nothing
-                // print(error)
             }
         }
 
@@ -240,7 +237,6 @@ class MockHelperTests: XCTestCase {
                 XCTAssertFalse(result, "P2SHMultisig: \(keys) Should fail but succeeds.")
             } catch {
                 // Expected fail:  do nothing
-                // print(error)
             }
         }
         


### PR DESCRIPTION
### Description of the Change
MockHelper for trying scripts that needs multiple signature.

### Alternate Designs
It may be ok to have only `MultiKeyScriptBuilder`. But for the beginners to easily understand the usage of Mocks, it'd be better to have both `SingleKeyScriptBuilder ` and `MultiKeyScriptBuilder`.

### Benefits
Enables to test scripts that needs multiple signature.

### Possible Drawbacks
None.

### Applicable Issues
closes #81