### PR TITLE
♻️ Remove the direct dependency to secp256k1

### DIFF
--- a/BitcoinKit/BitcoinKit.modulemap
+++ b/BitcoinKit/BitcoinKit.modulemap
@@ -7,5 +7,6 @@ framework module BitcoinKit {
     explicit module Private {
         header "BitcoinKitPrivate.h"
         link "crypto"
+        link "secp256k1"
     }
 }

--- a/BitcoinKit/BitcoinKitPrivate.h
+++ b/BitcoinKit/BitcoinKitPrivate.h
@@ -57,4 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface _Crypto : NSObject
++ (NSData *)signMessage:(NSData *)message withPrivateKey:(NSData *)privateKey;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/BitcoinKit/BitcoinKitPrivate.h
+++ b/BitcoinKit/BitcoinKitPrivate.h
@@ -59,6 +59,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface _Crypto : NSObject
 + (NSData *)signMessage:(NSData *)message withPrivateKey:(NSData *)privateKey;
++ (BOOL)verifySignature:(NSData *)signature message:(NSData *)message  publicKey:(NSData *)publicKey;
 @end
-
 NS_ASSUME_NONNULL_END

--- a/BitcoinKit/BitcoinKitPrivate.m
+++ b/BitcoinKit/BitcoinKitPrivate.m
@@ -216,7 +216,7 @@
     secp256k1_ecdsa_signature normalizedSignature;
     secp256k1_ecdsa_sign(ctx, &signature, message.bytes, privateKey.bytes, NULL, NULL);
     secp256k1_ecdsa_signature_normalize(ctx, &normalizedSignature, &signature);
-    size_t siglen = 128;
+    size_t siglen = 74;
     NSMutableData *der = [NSMutableData dataWithLength:siglen];
     secp256k1_ecdsa_signature_serialize_der(ctx, der.mutableBytes, &siglen, &normalizedSignature);
     der.length = siglen;
@@ -224,4 +224,20 @@
     return der;
 }
 
++ (BOOL)verifySignature:(NSData *)sigData message:(NSData *)message  publicKey:(NSData *)pubkeyData {
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    secp256k1_ecdsa_signature signature;
+    secp256k1_pubkey pubkey;
+
+    secp256k1_ecdsa_signature_parse_der(ctx, &signature, sigData.bytes, sigData.length);
+    if (secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyData.bytes, pubkeyData.length) != 1) {
+        return FALSE;
+    };
+    
+    if (secp256k1_ecdsa_verify(ctx, &signature, message.bytes, &pubkey) != 1) {
+        return FALSE;
+    };
+    secp256k1_context_destroy(ctx);
+    return TRUE;
+}
 @end

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
             dependencies: ["BitcoinKitPrivate", "secp256k1", "Random"]
         ),
         .target(
-            name: "BitcoinKitPrivate"
+            name: "BitcoinKitPrivate",
+            dependencies: ["COpenSSL", "secp256k1"]
         ),
         .testTarget(
             name: "BitcoinKitTests",

--- a/Sources/BitcoinKit/Core/Crypto.swift
+++ b/Sources/BitcoinKit/Core/Crypto.swift
@@ -29,7 +29,6 @@ import BitcoinKit.Private
 #else
 import BitcoinKitPrivate
 #endif
-import secp256k1
 
 public struct Crypto {
     public static func sha1(_ data: Data) -> Data {
@@ -66,26 +65,7 @@ public struct Crypto {
 
     public static func verifySignature(_ signature: Data, message: Data, publicKey: Data) throws -> Bool {
         #if BitcoinKitXcode
-        let ctx = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_VERIFY))!
-        defer { secp256k1_context_destroy(ctx) }
-
-        let signaturePointer = UnsafeMutablePointer<secp256k1_ecdsa_signature>.allocate(capacity: 1)
-        defer { signaturePointer.deallocate() }
-        guard signature.withUnsafeBytes({ secp256k1_ecdsa_signature_parse_der(ctx, signaturePointer, $0, signature.count) }) == 1 else {
-            print("signature : ", signature.hex)
-            throw CryptoError.signatureParseFailed
-        }
-
-        let pubkeyPointer = UnsafeMutablePointer<secp256k1_pubkey>.allocate(capacity: 1)
-        defer { pubkeyPointer.deallocate() }
-        guard publicKey.withUnsafeBytes({ secp256k1_ec_pubkey_parse(ctx, pubkeyPointer, $0, publicKey.count) }) == 1 else {
-            throw CryptoError.publicKeyParseFailed
-        }
-
-        guard message.withUnsafeBytes ({ secp256k1_ecdsa_verify(ctx, signaturePointer, $0, pubkeyPointer) }) == 1 else {
-            return false
-        }
-        return true
+        return _Crypto.verifySignature(signature, message: message, publicKey: publicKey)
         #else
         return try _Crypto.verifySignature(signature, message: message, publicKey: publicKey)
         #endif

--- a/Sources/BitcoinKit/Scripts/ScriptMachine.swift
+++ b/Sources/BitcoinKit/Scripts/ScriptMachine.swift
@@ -23,7 +23,6 @@
 //
 
 import Foundation
-import secp256k1
 
 public enum ScriptVerification {
     case StrictEncoding // enforce strict conformance to DER and SEC2 for signatures and pubkeys (aka SCRIPT_VERIFY_STRICTENC)

--- a/Sources/BitcoinKitPrivate/BitcoinKit.Private.swift
+++ b/Sources/BitcoinKitPrivate/BitcoinKit.Private.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import COpenSSL
+import secp256k1
 
 public class _Hash {
     public static func sha1(_ data: Data) -> Data {
@@ -241,5 +242,60 @@ public class _HDKey {
         } else {
             return nil
         }
+    }
+}
+
+public class _Crypto {
+    public static func signMessage(_ data: Data, withPrivateKey privateKey: Data) throws -> Data {
+        let ctx = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_SIGN))!
+        defer { secp256k1_context_destroy(ctx) }
+        
+        let signature = UnsafeMutablePointer<secp256k1_ecdsa_signature>.allocate(capacity: 1)
+        defer { signature.deallocate() }
+        let status = data.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
+            privateKey.withUnsafeBytes { secp256k1_ecdsa_sign(ctx, signature, ptr, $0, nil, nil) }
+        }
+        guard status == 1 else { throw CryptoError.signFailed }
+        
+        let normalizedsig = UnsafeMutablePointer<secp256k1_ecdsa_signature>.allocate(capacity: 1)
+        defer { normalizedsig.deallocate() }
+        secp256k1_ecdsa_signature_normalize(ctx, normalizedsig, signature)
+        
+        var length: size_t = 128
+        var der = Data(count: length)
+        guard der.withUnsafeMutableBytes({ return secp256k1_ecdsa_signature_serialize_der(ctx, $0, &length, normalizedsig) }) == 1 else { throw CryptoError.noEnoughSpace }
+        der.count = length
+        
+        return der
+    }
+    
+    public static func verifySignature(_ signature: Data, message: Data, publicKey: Data) throws -> Bool {
+        let ctx = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_VERIFY))!
+        defer { secp256k1_context_destroy(ctx) }
+        
+        let signaturePointer = UnsafeMutablePointer<secp256k1_ecdsa_signature>.allocate(capacity: 1)
+        defer { signaturePointer.deallocate() }
+        guard signature.withUnsafeBytes({ secp256k1_ecdsa_signature_parse_der(ctx, signaturePointer, $0, signature.count) }) == 1 else {
+            throw CryptoError.signatureParseFailed
+        }
+        
+        let pubkeyPointer = UnsafeMutablePointer<secp256k1_pubkey>.allocate(capacity: 1)
+        defer { pubkeyPointer.deallocate() }
+        guard publicKey.withUnsafeBytes({ secp256k1_ec_pubkey_parse(ctx, pubkeyPointer, $0, publicKey.count) }) == 1 else {
+            throw CryptoError.publicKeyParseFailed
+        }
+        
+        guard message.withUnsafeBytes ({ secp256k1_ecdsa_verify(ctx, signaturePointer, $0, pubkeyPointer) }) == 1 else {
+            return false
+        }
+        
+        return true
+    }
+    
+    public enum CryptoError: Error {
+        case signFailed
+        case noEnoughSpace
+        case signatureParseFailed
+        case publicKeyParseFailed
     }
 }


### PR DESCRIPTION
### Description of the Change
Currently `Crypto.swift` and `ScriptMachine.swift` has a direct dependency to secp256k1.
So, remove the dependency.

### Alternate Designs
Each users copy `Libraries/secp256k1`, and then set this path to `SWIFT_INCLUDE_PATHS`.

### Benefits
This PR enables Binary build installation.

### Possible Drawbacks
For Linux, it is not solved yet.

### Applicable Issues
closes #160 