### PR TITLE
Swift4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
+Package.resolved
 .build/
 
 # CocoaPods

--- a/BitcoinKit.xcodeproj/project.pbxproj
+++ b/BitcoinKit.xcodeproj/project.pbxproj
@@ -940,11 +940,12 @@
 				TargetAttributes = {
 					147494C6201F9A29006D1CF8 = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 					147494CF201F9A29006D1CF8 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1400,7 +1401,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Libraries";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1438,7 +1439,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Libraries";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1458,7 +1459,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitcoinkit.BitcoinKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1478,7 +1479,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitcoinkit.BitcoinKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Sources/BitcoinKit/Core/Keys/QRCodeGenerator.swift
+++ b/Sources/BitcoinKit/Core/Keys/QRCodeGenerator.swift
@@ -31,7 +31,7 @@ public struct QRCodeGenerator {
             "inputMessage": string.data(using: .utf8)!,
             "inputCorrectionLevel": "L"
         ]
-        guard let image = CIFilter(name: "CIQRCodeGenerator", withInputParameters: parameters)?.outputImage else {
+        guard let image = CIFilter(name: "CIQRCodeGenerator", parameters: parameters)?.outputImage else {
             return nil
         }
 

--- a/Sources/BitcoinKit/Networking/Peer.swift
+++ b/Sources/BitcoinKit/Networking/Peer.swift
@@ -90,8 +90,8 @@ public class Peer: NSObject, StreamDelegate {
         inputStream.delegate = self
         outputStream.delegate = self
 
-        inputStream.schedule(in: .current, forMode: .commonModes)
-        outputStream.schedule(in: .current, forMode: .commonModes)
+        inputStream.schedule(in: .current, forMode: .common)
+        outputStream.schedule(in: .current, forMode: .common)
 
         inputStream.open()
         outputStream.open()
@@ -104,8 +104,8 @@ public class Peer: NSObject, StreamDelegate {
 
         inputStream.delegate = nil
         outputStream.delegate = nil
-        inputStream.remove(from: .current, forMode: .commonModes)
-        outputStream.remove(from: .current, forMode: .commonModes)
+        inputStream.remove(from: .current, forMode: .common)
+        outputStream.remove(from: .current, forMode: .common)
         inputStream.close()
         outputStream.close()
         readStream = nil

--- a/Sources/BitcoinKit/Scripts/OP_CODE/Splice/OP_SPLIT.swift
+++ b/Sources/BitcoinKit/Scripts/OP_CODE/Splice/OP_SPLIT.swift
@@ -41,8 +41,8 @@ public struct OpSplit: OpCodeProtocol {
             throw OpCodeExecutionError.error("Invalid OP_SPLIT range")
         }
 
-        let n1: Data = data.subdata(in: Range(0..<Int(position)))
-        let n2: Data = data.subdata(in: Range(Int(position)..<data.count))
+        let n1: Data = data.subdata(in: 0..<Int(position))
+        let n2: Data = data.subdata(in: Int(position)..<data.count)
 
         // Replace existing stack values by the new values.
         context.stack[context.stack.count - 2] = n1

--- a/Sources/BitcoinKit/Scripts/OP_CODE/Stack/OP_2ROT.swift
+++ b/Sources/BitcoinKit/Scripts/OP_CODE/Stack/OP_2ROT.swift
@@ -36,7 +36,7 @@ public struct Op2Rot: OpCodeProtocol {
         let x1: Data = context.data(at: -6)
         let x2: Data = context.data(at: -5)
         let count: Int = context.stack.count
-        context.stack.removeSubrange(Range(count - 6 ..< count - 4))
+        context.stack.removeSubrange(count - 6 ..< count - 4)
         context.stack.append(x1)
         context.stack.append(x2)
     }

--- a/Sources/BitcoinKit/Scripts/Script.swift
+++ b/Sources/BitcoinKit/Scripts/Script.swift
@@ -396,7 +396,7 @@ public class Script {
 
     public func subScript(from index: Int) throws -> Script {
         let subScript: Script = Script()
-        for chunk in chunks[Range(index..<chunks.count)] {
+        for chunk in chunks[index..<chunks.count] {
             try subScript.appendData(chunk.chunkData)
         }
         return subScript
@@ -404,7 +404,7 @@ public class Script {
 
     public func subScript(to index: Int) throws -> Script {
         let subScript: Script = Script()
-        for chunk in chunks[Range(0..<index)] {
+        for chunk in chunks[0..<index] {
             try subScript.appendData(chunk.chunkData)
         }
         return subScript

--- a/Sources/BitcoinKit/Scripts/ScriptChunk.swift
+++ b/Sources/BitcoinKit/Scripts/ScriptChunk.swift
@@ -121,7 +121,7 @@ public struct DataChunk: ScriptChunk {
             loc += 4
         }
 
-        return scriptData.subdata(in: Range((range.lowerBound + loc)..<(range.upperBound)))
+        return scriptData.subdata(in: (range.lowerBound + loc)..<(range.upperBound))
     }
 
     public var string: String {

--- a/Sources/BitcoinKit/Scripts/ScriptChunkHelper.swift
+++ b/Sources/BitcoinKit/Scripts/ScriptChunkHelper.swift
@@ -65,7 +65,7 @@ public struct ScriptChunkHelper {
 
         if opcode > OpCode.OP_PUSHDATA4 {
             // simple opcode
-            let range = Range(offset..<offset + MemoryLayout.size(ofValue: opcode))
+            let range = (offset..<offset + MemoryLayout.size(ofValue: opcode))
             return OpcodeChunk(scriptData: scriptData, range: range)
         } else {
             // push data
@@ -119,7 +119,7 @@ public struct ScriptChunkHelper {
         guard offset + chunkLength <= count else {
             throw ScriptChunkError.error("Parse DataChunk failed. Push data is out of bounds error.")
         }
-        let range: Range<Int> = Range(offset..<offset + chunkLength)
+        let range = (offset..<offset + chunkLength)
         return DataChunk(scriptData: scriptData, range: range)
     }
 }

--- a/WalletExample/WalletExample.xcodeproj/project.pbxproj
+++ b/WalletExample/WalletExample.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 				TargetAttributes = {
 					298E17DA2150C55C00FF6C77 = {
 						CreatedOnToolsVersion = 9.4.1;
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -225,7 +226,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -279,7 +280,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -300,7 +301,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = tech.yenom.WalletExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -317,7 +318,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = tech.yenom.WalletExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/WalletExample/WalletExample/AppDelegate.swift
+++ b/WalletExample/WalletExample/AppDelegate.swift
@@ -30,10 +30,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
+    
+    
 
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change
Converted from Swift 4.1.2 to 4.2
- Most of Range() is not needed any more
- Some name change by default

### Alternate Designs
Do nothing.

### Benefits
Modern language.

### Possible Drawbacks
Users who are using Xcode 9.0 or older cannot use BitcoinKit.
I'm not sure about this.

### Applicable Issues
closes #163