### PR TITLE
Swift4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
+Package.resolved
 .build/
 
 # CocoaPods

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.4
+osx_image: xcode10
 cache:
   directories:
   - Libraries

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
 - xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -configuration "$CONFIGURATION"
   -sdk "$SDK" -destination "$DESTINATION" -derivedDataPath build
   -enableCodeCoverage YES ENABLE_TESTABILITY=YES "$ACTION"
+- swift -version
 - swift test
 after_success:
 - ruby scripts/coverage.rb "$SCHEME"

--- a/BitcoinKit.xcodeproj/project.pbxproj
+++ b/BitcoinKit.xcodeproj/project.pbxproj
@@ -943,11 +943,12 @@
 				TargetAttributes = {
 					147494C6201F9A29006D1CF8 = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 					147494CF201F9A29006D1CF8 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1404,7 +1405,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Libraries";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1442,7 +1443,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Libraries";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1462,7 +1463,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitcoinkit.BitcoinKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1482,7 +1483,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitcoinkit.BitcoinKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/BitcoinKit.xcodeproj/project.pbxproj
+++ b/BitcoinKit.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		2949920220F228B400D078B6 /* UnspentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2949920120F228B400D078B6 /* UnspentTransaction.swift */; };
 		2949920420F22A1500D078B6 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2949920320F22A1500D078B6 /* TestHelpers.swift */; };
 		2949920620F22DCA00D078B6 /* UnsignedTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2949920520F22DCA00D078B6 /* UnsignedTransaction.swift */; };
+		294D6CB6215A124700B75928 /* SerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294D6CB5215A124700B75928 /* SerializationTests.swift */; };
 		294DDE32211A05D200B7F645 /* OP_RETURN.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294DDE31211A05D200B7F645 /* OP_RETURN.swift */; };
 		294DDE3B211B31B100B7F645 /* OP_NOP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294DDE3A211B31B100B7F645 /* OP_NOP.swift */; };
 		294DDE3D211B31C100B7F645 /* OP_VER.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294DDE3C211B31C100B7F645 /* OP_VER.swift */; };
@@ -384,6 +385,7 @@
 		2949920120F228B400D078B6 /* UnspentTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnspentTransaction.swift; sourceTree = "<group>"; };
 		2949920320F22A1500D078B6 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		2949920520F22DCA00D078B6 /* UnsignedTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsignedTransaction.swift; sourceTree = "<group>"; };
+		294D6CB5215A124700B75928 /* SerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializationTests.swift; sourceTree = "<group>"; };
 		294DDE31211A05D200B7F645 /* OP_RETURN.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OP_RETURN.swift; sourceTree = "<group>"; };
 		294DDE3A211B31B100B7F645 /* OP_NOP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OP_NOP.swift; sourceTree = "<group>"; };
 		294DDE3C211B31C100B7F645 /* OP_VER.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OP_VER.swift; sourceTree = "<group>"; };
@@ -577,6 +579,7 @@
 				6E20AED62112D417008A9810 /* MurmurHashTests.swift */,
 				6E797C442116C8A5003BEDFD /* OpCodeFactoryTests.swift */,
 				29089F0D2122BE7200E0C305 /* MockHelperTests.swift */,
+				294D6CB5215A124700B75928 /* SerializationTests.swift */,
 			);
 			name = BitcoinKitTests;
 			path = Tests/BitcoinKitTests;
@@ -943,12 +946,11 @@
 				TargetAttributes = {
 					147494C6201F9A29006D1CF8 = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 0920;
 						ProvisioningStyle = Automatic;
 					};
 					147494CF201F9A29006D1CF8 = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1236,6 +1238,7 @@
 				29F5D1E02110495F007DA3BF /* OpCodeTests.swift in Sources */,
 				6E20AEC92112C31A008A9810 /* LegacyAddressTests.swift in Sources */,
 				6E20AED12112C6AA008A9810 /* PaymentURITests.swift in Sources */,
+				294D6CB6215A124700B75928 /* SerializationTests.swift in Sources */,
 				CF432AF220F0CF9100AD4020 /* Base58Tests.swift in Sources */,
 				2949920420F22A1500D078B6 /* TestHelpers.swift in Sources */,
 				29F5D1E421106772007DA3BF /* BigNumberTests.swift in Sources */,

--- a/BitcoinKit/BitcoinKitPrivate.h
+++ b/BitcoinKit/BitcoinKitPrivate.h
@@ -46,13 +46,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface _HDKey : NSObject
 
 @property (nonatomic, readonly, nullable) NSData *privateKey;
-@property (nonatomic, readonly, nullable) NSData *publicKey;
+@property (nonatomic, readonly) NSData *publicKey;
 @property (nonatomic, readonly) NSData *chainCode;
 @property (nonatomic, readonly) uint8_t depth;
 @property (nonatomic, readonly) uint32_t fingerprint;
 @property (nonatomic, readonly) uint32_t childIndex;
 
-- (instancetype)initWithPrivateKey:(nullable NSData *)privateKey publicKey:(nullable NSData *)publicKey chainCode:(NSData *)chainCode depth:(uint8_t)depth fingerprint:(uint32_t)fingerprint childIndex:(uint32_t)childIndex;
+- (instancetype)initWithPrivateKey:(nullable NSData *)privateKey publicKey:(NSData *)publicKey chainCode:(NSData *)chainCode depth:(uint8_t)depth fingerprint:(uint32_t)fingerprint childIndex:(uint32_t)childIndex;
 - (nullable _HDKey *)derivedAtIndex:(uint32_t)childIndex hardened:(BOOL)hardened;
 
 @end

--- a/Sources/BitcoinKit/Core/Keys/HDPublicKey.swift
+++ b/Sources/BitcoinKit/Core/Keys/HDPublicKey.swift
@@ -72,7 +72,7 @@ public class HDPublicKey {
         guard let derivedKey = _HDKey(privateKey: nil, publicKey: raw, chainCode: chainCode, depth: depth, fingerprint: fingerprint, childIndex: childIndex).derived(at: index, hardened: false) else {
             throw DerivationError.derivationFailed
         }
-        return HDPublicKey(raw: derivedKey.publicKey!, chainCode: derivedKey.chainCode, network: network, depth: derivedKey.depth, fingerprint: derivedKey.fingerprint, childIndex: derivedKey.childIndex)
+        return HDPublicKey(raw: derivedKey.publicKey, chainCode: derivedKey.chainCode, network: network, depth: derivedKey.depth, fingerprint: derivedKey.fingerprint, childIndex: derivedKey.childIndex)
     }
 }
 

--- a/Sources/BitcoinKit/Core/Keys/QRCodeGenerator.swift
+++ b/Sources/BitcoinKit/Core/Keys/QRCodeGenerator.swift
@@ -31,7 +31,7 @@ public struct QRCodeGenerator {
             "inputMessage": string.data(using: .utf8)!,
             "inputCorrectionLevel": "L"
         ]
-        guard let image = CIFilter(name: "CIQRCodeGenerator", withInputParameters: parameters)?.outputImage else {
+        guard let image = CIFilter(name: "CIQRCodeGenerator", parameters: parameters)?.outputImage else {
             return nil
         }
 

--- a/Sources/BitcoinKit/Core/Serialization.swift
+++ b/Sources/BitcoinKit/Core/Serialization.swift
@@ -91,7 +91,11 @@ extension Data {
     }
 
     func to<T>(type: T.Type) -> T {
-        return self.withUnsafeBytes { $0.pointee }
+        var data = self
+        while data.count < MemoryLayout<T>.size {
+            data.append(0)
+        }
+        return data.withUnsafeBytes { $0.pointee }
     }
 
     func to(type: String.Type) -> String {

--- a/Sources/BitcoinKit/Networking/Peer.swift
+++ b/Sources/BitcoinKit/Networking/Peer.swift
@@ -90,8 +90,8 @@ public class Peer: NSObject, StreamDelegate {
         inputStream.delegate = self
         outputStream.delegate = self
 
-        inputStream.schedule(in: .current, forMode: .commonModes)
-        outputStream.schedule(in: .current, forMode: .commonModes)
+        inputStream.schedule(in: .current, forMode: .common)
+        outputStream.schedule(in: .current, forMode: .common)
 
         inputStream.open()
         outputStream.open()
@@ -104,8 +104,8 @@ public class Peer: NSObject, StreamDelegate {
 
         inputStream.delegate = nil
         outputStream.delegate = nil
-        inputStream.remove(from: .current, forMode: .commonModes)
-        outputStream.remove(from: .current, forMode: .commonModes)
+        inputStream.remove(from: .current, forMode: .common)
+        outputStream.remove(from: .current, forMode: .common)
         inputStream.close()
         outputStream.close()
         readStream = nil

--- a/Sources/BitcoinKit/Networking/Peer.swift
+++ b/Sources/BitcoinKit/Networking/Peer.swift
@@ -90,8 +90,13 @@ public class Peer: NSObject, StreamDelegate {
         inputStream.delegate = self
         outputStream.delegate = self
 
+        #if BitcoinKitXcode
         inputStream.schedule(in: .current, forMode: .common)
         outputStream.schedule(in: .current, forMode: .common)
+        #else
+        inputStream.schedule(in: .current, forMode: RunLoopMode.commonModes)
+        outputStream.schedule(in: .current, forMode: RunLoopMode.commonModes)
+        #endif
 
         inputStream.open()
         outputStream.open()
@@ -104,8 +109,14 @@ public class Peer: NSObject, StreamDelegate {
 
         inputStream.delegate = nil
         outputStream.delegate = nil
+        #if BitcoinKitXcode
         inputStream.remove(from: .current, forMode: .common)
         outputStream.remove(from: .current, forMode: .common)
+        #else
+        inputStream.remove(from: .current, forMode: RunLoopMode.commonModes)
+        outputStream.remove(from: .current, forMode: RunLoopMode.commonModes)
+        #endif
+
         inputStream.close()
         outputStream.close()
         readStream = nil

--- a/Sources/BitcoinKit/Scripts/OP_CODE/Splice/OP_SPLIT.swift
+++ b/Sources/BitcoinKit/Scripts/OP_CODE/Splice/OP_SPLIT.swift
@@ -41,8 +41,8 @@ public struct OpSplit: OpCodeProtocol {
             throw OpCodeExecutionError.error("Invalid OP_SPLIT range")
         }
 
-        let n1: Data = data.subdata(in: Range(0..<Int(position)))
-        let n2: Data = data.subdata(in: Range(Int(position)..<data.count))
+        let n1: Data = data.subdata(in: 0..<Int(position))
+        let n2: Data = data.subdata(in: Int(position)..<data.count)
 
         // Replace existing stack values by the new values.
         context.stack[context.stack.count - 2] = n1

--- a/Sources/BitcoinKit/Scripts/OP_CODE/Stack/OP_2ROT.swift
+++ b/Sources/BitcoinKit/Scripts/OP_CODE/Stack/OP_2ROT.swift
@@ -36,7 +36,7 @@ public struct Op2Rot: OpCodeProtocol {
         let x1: Data = context.data(at: -6)
         let x2: Data = context.data(at: -5)
         let count: Int = context.stack.count
-        context.stack.removeSubrange(Range(count - 6 ..< count - 4))
+        context.stack.removeSubrange(count - 6 ..< count - 4)
         context.stack.append(x1)
         context.stack.append(x2)
     }

--- a/Sources/BitcoinKit/Scripts/Script.swift
+++ b/Sources/BitcoinKit/Scripts/Script.swift
@@ -396,7 +396,7 @@ public class Script {
 
     public func subScript(from index: Int) throws -> Script {
         let subScript: Script = Script()
-        for chunk in chunks[Range(index..<chunks.count)] {
+        for chunk in chunks[index..<chunks.count] {
             try subScript.appendData(chunk.chunkData)
         }
         return subScript
@@ -404,7 +404,7 @@ public class Script {
 
     public func subScript(to index: Int) throws -> Script {
         let subScript: Script = Script()
-        for chunk in chunks[Range(0..<index)] {
+        for chunk in chunks[0..<index] {
             try subScript.appendData(chunk.chunkData)
         }
         return subScript

--- a/Sources/BitcoinKit/Scripts/ScriptChunk.swift
+++ b/Sources/BitcoinKit/Scripts/ScriptChunk.swift
@@ -121,7 +121,7 @@ public struct DataChunk: ScriptChunk {
             loc += 4
         }
 
-        return scriptData.subdata(in: Range((range.lowerBound + loc)..<(range.upperBound)))
+        return scriptData.subdata(in: (range.lowerBound + loc)..<(range.upperBound))
     }
 
     public var string: String {

--- a/Sources/BitcoinKit/Scripts/ScriptChunkHelper.swift
+++ b/Sources/BitcoinKit/Scripts/ScriptChunkHelper.swift
@@ -65,7 +65,7 @@ public struct ScriptChunkHelper {
 
         if opcode > OpCode.OP_PUSHDATA4 {
             // simple opcode
-            let range = Range(offset..<offset + MemoryLayout.size(ofValue: opcode))
+            let range = (offset..<offset + MemoryLayout.size(ofValue: opcode))
             return OpcodeChunk(scriptData: scriptData, range: range)
         } else {
             // push data
@@ -119,7 +119,7 @@ public struct ScriptChunkHelper {
         guard offset + chunkLength <= count else {
             throw ScriptChunkError.error("Parse DataChunk failed. Push data is out of bounds error.")
         }
-        let range: Range<Int> = Range(offset..<offset + chunkLength)
+        let range = (offset..<offset + chunkLength)
         return DataChunk(scriptData: scriptData, range: range)
     }
 }

--- a/Sources/BitcoinKitPrivate/BitcoinKit.Private.swift
+++ b/Sources/BitcoinKitPrivate/BitcoinKit.Private.swift
@@ -133,15 +133,21 @@ public class _HDKey {
         self.childIndex = childIndex
     }
     public func derived(at index: UInt32, hardened: Bool) -> _HDKey? {
-        
+        // index should be 0 through 2^31-1
+        guard index < 0x80000000 else {
+            return nil
+        }
         let ctx = BN_CTX_new()
         defer {
             BN_CTX_free(ctx)
         }
         var data = Data()
         if hardened {
-            data.append(0) // padding
-            data += privateKey ?? Data()
+            guard let privateKey = privateKey else {
+                return nil
+            }
+            data.append(0) // pads the private key to make it 33 bytes long
+            data += privateKey
         } else {
             data += publicKey
         }

--- a/Tests/BitcoinKitTests/CryptoTests.swift
+++ b/Tests/BitcoinKitTests/CryptoTests.swift
@@ -52,4 +52,11 @@ class CryptoTests: XCTestCase {
         XCTAssertNotNil(signature)
         XCTAssertEqual(signature?.hex, "3044022055f4b20035cbb2e85b7a04a0874c80d5822758f4e47a9a69db04b29f8b218f920220491e6a13296cfe2186da3a3ca565a179def3808b12d184553a8e3acfe1467273")
     }
+    
+    func testHMAC() {
+        let testStr = "param1=val1&param2=val2"
+        let secretKey = "password"
+        let result = Crypto.hmacsha512(data: testStr.data(using: .utf8)!, key: secretKey.data(using: .utf8)!)
+        XCTAssertEqual(result.hex, "051464ad12cd03cf6c0f968317dfcededafeb8a267d6da7869e0588aa887bde6f4f0fe2077aed2a32a748c9e2d59ddc2bb7c3f034a4aa9fc9b0752c750daae94")
+    }
 }

--- a/Tests/BitcoinKitTests/MockHelperTests.swift
+++ b/Tests/BitcoinKitTests/MockHelperTests.swift
@@ -104,6 +104,12 @@ class MockHelperTests: XCTestCase {
             }
         }
     }
+    
+    func testP2SHRecursively() {
+        for _ in 0...30 {
+            testP2SH()
+        }
+    }
 
     func testP2SH() {
         func verify(with key: MockKey) throws -> Bool {

--- a/Tests/BitcoinKitTests/MockHelperTests.swift
+++ b/Tests/BitcoinKitTests/MockHelperTests.swift
@@ -105,12 +105,6 @@ class MockHelperTests: XCTestCase {
         }
     }
     
-    func testP2SHRecursively() {
-        for _ in 0...30 {
-            testP2SH()
-        }
-    }
-
     func testP2SH() {
         func verify(with key: MockKey) throws -> Bool {
             return try MockHelper.verifySingleKey(

--- a/Tests/BitcoinKitTests/SerializationTests.swift
+++ b/Tests/BitcoinKitTests/SerializationTests.swift
@@ -1,9 +1,25 @@
 //
 //  SerializationTests.swift
-//  BitcoinKitTests
 //
-//  Created by Shun Usami on 2018/09/25.
-//  Copyright © 2018 BitcoinKit developers. All rights reserved.
+//  Copyright © 2018 BitcoinKit developers
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import XCTest

--- a/Tests/BitcoinKitTests/SerializationTests.swift
+++ b/Tests/BitcoinKitTests/SerializationTests.swift
@@ -1,0 +1,24 @@
+//
+//  SerializationTests.swift
+//  BitcoinKitTests
+//
+//  Created by Shun Usami on 2018/09/25.
+//  Copyright © 2018 BitcoinKit developers. All rights reserved.
+//
+
+import XCTest
+@testable import BitcoinKit
+
+class SerializationTests: XCTestCase {
+
+    func testDataToInt32() {
+        for _ in 0..<10 {
+            for i in 0...255 {
+                let data: Data = Data([UInt8(i)])
+                let intValue: Int32 = data.to(type: Int32.self)
+                XCTAssertEqual(intValue, Int32(i), "\(i) time")
+            }
+        }
+    }
+
+}

--- a/WalletExample/WalletExample.xcodeproj/project.pbxproj
+++ b/WalletExample/WalletExample.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 				TargetAttributes = {
 					298E17DA2150C55C00FF6C77 = {
 						CreatedOnToolsVersion = 9.4.1;
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -225,7 +226,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -279,7 +280,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -300,7 +301,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = tech.yenom.WalletExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -317,7 +318,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = tech.yenom.WalletExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/WalletExample/WalletExample/AppDelegate.swift
+++ b/WalletExample/WalletExample/AppDelegate.swift
@@ -30,10 +30,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
+    
+    
 
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change
Converted from Swift 4.1.2 to 4.2
- Most of Range() is not needed any more
- Some name change by default

### Alternate Designs
Do nothing.

### Benefits
Modern language.

### Possible Drawbacks
Users who are using Xcode 9.0 or older cannot use BitcoinKit.
I'm not sure about this.

### Applicable Issues
closes #163