### PR TITLE
Change PublicKey initializer scope to public.

### DIFF
--- a/Sources/BitcoinKit/Core/Keys/PublicKey.swift
+++ b/Sources/BitcoinKit/Core/Keys/PublicKey.swift
@@ -40,7 +40,7 @@ public struct PublicKey {
     public let network: Network
     public let isCompressed: Bool
 
-    init(bytes data: Data, network: Network) {
+    public init(bytes data: Data, network: Network) {
         self.data = data
         self.network = network
         let header = data[0]


### PR DESCRIPTION
### Description of the Change

- Changed initializer scope of `PublicKey` to public.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->


### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
