### PR TITLE
:sparkles: Add isStandardOpReturnScript, retrieveOpReturnData to Script

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -30,6 +30,6 @@ type_name:
   excluded:
 type_body_length: 500
 line_length: 300
-file_length: 500
+file_length: 1000
 number_separator:
   minimum_length: 5

--- a/Sources/BitcoinKit/Scripts/Script.swift
+++ b/Sources/BitcoinKit/Scripts/Script.swift
@@ -262,7 +262,7 @@ public class Script {
             && pushedData(at: 1) != nil
     }
 
-    public var retrieveOpReturnData: Data? {
+    public func standardOpReturnData() -> Data? {
         guard isStandardOpReturnScript else {
             return nil
         }

--- a/Sources/BitcoinKit/Scripts/Script.swift
+++ b/Sources/BitcoinKit/Scripts/Script.swift
@@ -254,6 +254,21 @@ public class Script {
         return requirements.nSigRequired > 0
     }
 
+    public var isStandardOpReturnScript: Bool {
+        guard chunks.count == 2 else {
+            return false
+        }
+        return opcode(at: 0) == .OP_RETURN
+            && pushedData(at: 1) != nil
+    }
+
+    public var retrieveOpReturnData: Data? {
+        guard isStandardOpReturnScript else {
+            return nil
+        }
+        return pushedData(at: 1)
+    }
+
     // If typical multisig tx is detected, sets requirements:
     private func detectMultisigScript() {
         // multisig script must have at least 4 ops ("OP_1 <pubkey> OP_1 OP_CHECKMULTISIG")


### PR DESCRIPTION
### Description of the Change
Added these to Script.
`isStandardOpReturnScript: Bool`
`standardOpReturnData() -> Data?`

### Benefits
Easily retrieve OP_RETURN data.