### PR TITLE
Add verify check if each word included.

### DIFF
--- a/Sources/BitcoinKit/Core/Mnemonic.swift
+++ b/Sources/BitcoinKit/Core/Mnemonic.swift
@@ -85,6 +85,14 @@ public struct Mnemonic {
         return seed
     }
 
+    public static func verify(mnemonic m: [String], language: Language = .english) -> Bool {
+        let list = wordList(for: language)
+        let notIncludedIndex = m.firstIndex {
+            return !list.contains(String.SubSequence($0))
+        }
+        return notIncludedIndex == nil
+    }
+
     private static func wordList(for language: Language) -> [String.SubSequence] {
         switch language {
         case .english:


### PR DESCRIPTION
# Conflicts:
#	Sources/BitcoinKit/Core/Mnemonic.swift

### Requirements

Check all words of user input is included in the Mnemonic list.

### Description of the Change

Check all words of user input is included in the Mnemonic list. if not, most time cannot do create seed.

### Alternate Designs

It's useful for developers to check input legality, otherwise random words that not included the list also get a seed.


### Benefits

Maybe more friendily.

### Applicable Issues

Although any input can create a seed, most time user input words should be checked.

