### PR TITLE
change library openssl to secp256k1 for converting priv key to pub key

### DIFF
--- a/BitcoinKit.xcodeproj/project.pbxproj
+++ b/BitcoinKit.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		6E20AED72112D417008A9810 /* MurmurHashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20AED62112D417008A9810 /* MurmurHashTests.swift */; };
 		6E797C452116C8A5003BEDFD /* OpCodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E797C442116C8A5003BEDFD /* OpCodeFactoryTests.swift */; };
 		6EE789DB2112C1E500EAB620 /* CryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE789DA2112C1E500EAB620 /* CryptoTests.swift */; };
+		A201ABB6222ACF7100DEFE13 /* BitcoinKitPrivateSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = A201ABB5222ACF7100DEFE13 /* BitcoinKitPrivateSwift.swift */; };
 		CF432AF220F0CF9100AD4020 /* Base58Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF432AF120F0CF9100AD4020 /* Base58Tests.swift */; };
 		CF432AF420F0DFAC00AD4020 /* Bech32Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF432AF320F0DFAC00AD4020 /* Bech32Tests.swift */; };
 		CF432AF620F0ED4500AD4020 /* AddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF432AF520F0ED4500AD4020 /* AddressTests.swift */; };
@@ -433,6 +434,7 @@
 		6E20AED62112D417008A9810 /* MurmurHashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MurmurHashTests.swift; sourceTree = "<group>"; };
 		6E797C442116C8A5003BEDFD /* OpCodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpCodeFactoryTests.swift; sourceTree = "<group>"; };
 		6EE789DA2112C1E500EAB620 /* CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoTests.swift; sourceTree = "<group>"; };
+		A201ABB5222ACF7100DEFE13 /* BitcoinKitPrivateSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BitcoinKitPrivateSwift.swift; path = Core/BitcoinKitPrivateSwift.swift; sourceTree = "<group>"; };
 		CF432AF120F0CF9100AD4020 /* Base58Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base58Tests.swift; sourceTree = "<group>"; };
 		CF432AF320F0DFAC00AD4020 /* Bech32Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bech32Tests.swift; sourceTree = "<group>"; };
 		CF432AF520F0ED4500AD4020 /* AddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressTests.swift; sourceTree = "<group>"; };
@@ -543,6 +545,7 @@
 				1419E838202CDBE500FCB0BE /* BitcoinKitPrivate.h */,
 				1419E839202CDBE500FCB0BE /* BitcoinKitPrivate.m */,
 				147494CB201F9A29006D1CF8 /* Info.plist */,
+				A201ABB5222ACF7100DEFE13 /* BitcoinKitPrivateSwift.swift */,
 			);
 			name = BitcoinKit;
 			path = Sources/BitcoinKit;
@@ -1206,6 +1209,7 @@
 				0C0900362116A62E0077E9BC /* OP_0NOTEQUAL.swift in Sources */,
 				0C1DE15D211E6EB400FE8E43 /* OP_DROP.swift in Sources */,
 				299CB47320F0185500B1245C /* TransactionSignatureSerializer.swift in Sources */,
+				A201ABB6222ACF7100DEFE13 /* BitcoinKitPrivateSwift.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BitcoinKit/BitcoinKitPrivate.h
+++ b/BitcoinKit/BitcoinKitPrivate.h
@@ -38,7 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface _Key : NSObject
 
-+ (NSData *)computePublicKeyFromPrivateKey:(NSData *)privateKey compression:(BOOL)compression;
 + (NSData *)deriveKey:(NSData *)password salt:(NSData *)salt iterations:(NSInteger)iterations keyLength:(NSInteger)keyLength;
 
 @end

--- a/BitcoinKit/BitcoinKitPrivate.m
+++ b/BitcoinKit/BitcoinKitPrivate.m
@@ -70,41 +70,6 @@
 
 @implementation _Key
 
-+ (NSData *)computePublicKeyFromPrivateKey:(NSData *)privateKey compression:(BOOL)compression {
-    BN_CTX *ctx = BN_CTX_new();
-    EC_KEY *key = EC_KEY_new_by_curve_name(NID_secp256k1);
-    const EC_GROUP *group = EC_KEY_get0_group(key);
-
-    BIGNUM *prv = BN_new();
-    BN_bin2bn(privateKey.bytes, (int)privateKey.length, prv);
-
-    EC_POINT *pub = EC_POINT_new(group);
-    EC_POINT_mul(group, pub, prv, nil, nil, ctx);
-    EC_KEY_set_private_key(key, prv);
-    EC_KEY_set_public_key(key, pub);
-
-    NSMutableData *result;
-    if (compression) {
-        EC_KEY_set_conv_form(key, POINT_CONVERSION_COMPRESSED);
-        unsigned char *bytes = NULL;
-        int length = i2o_ECPublicKey(key, &bytes);
-        result = [NSMutableData dataWithBytesNoCopy:bytes length:length];
-    } else {
-        result = [NSMutableData dataWithLength:65];
-        BIGNUM *n = BN_new();
-        EC_POINT_point2bn(group, pub, POINT_CONVERSION_UNCOMPRESSED, n, ctx);
-        BN_bn2bin(n, result.mutableBytes);
-        BN_free(n);
-    }
-
-    EC_POINT_free(pub);
-    BN_free(prv);
-    EC_KEY_free(key);
-    BN_CTX_free(ctx);
-
-    return result;
-}
-
 + (NSData *)deriveKey:(NSData *)password salt:(NSData *)salt iterations:(NSInteger)iterations keyLength:(NSInteger)keyLength {
     NSMutableData *result = [NSMutableData dataWithLength:keyLength];
     PKCS5_PBKDF2_HMAC(password.bytes, (int)password.length, salt.bytes, (int)salt.length, (int)iterations, EVP_sha512(), (int)keyLength, result.mutableBytes);

--- a/Sources/BitcoinKit/Core/BitcoinKitPrivateSwift.swift
+++ b/Sources/BitcoinKit/Core/BitcoinKitPrivateSwift.swift
@@ -1,0 +1,64 @@
+//
+//  BitcoinKitPrivateSwift.swift
+//
+//  Copyright © 2019 BitcoinKit developers
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import secp256k1
+
+class _SwiftKey {
+	public static func computePublicKey(fromPrivateKey privateKey: Data, compression: Bool) -> Data {
+		guard let ctx = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_SIGN)) else {
+			return Data()
+		}
+		defer { secp256k1_context_destroy(ctx) }
+		var pubkey = secp256k1_pubkey()
+		var seckey: [UInt8] = privateKey.map{ $0 }
+		if seckey.count != 32 {
+			return Data()
+		}
+		if secp256k1_ec_pubkey_create(ctx, &pubkey, &seckey) == 0 {
+			return Data()
+		}
+		if compression {
+			var serializedPubkey = [UInt8](repeating: 0, count: 33)
+			var outputlen = 33
+			if secp256k1_ec_pubkey_serialize(ctx, &serializedPubkey, &outputlen, &pubkey, UInt32(SECP256K1_EC_COMPRESSED)) == 0 {
+				return Data()
+			}
+			if outputlen != 33 {
+				return Data()
+			}
+			return Data(bytes: serializedPubkey)			
+		} else {
+    		var serializedPubkey = [UInt8](repeating: 0, count: 65)
+    		var outputlen = 65 
+    		if secp256k1_ec_pubkey_serialize(ctx, &serializedPubkey, &outputlen, &pubkey, UInt32(SECP256K1_EC_UNCOMPRESSED)) == 0 {
+    			return Data()
+    		}
+    		if outputlen != 65 {
+    			return Data()
+    		}
+    		return Data(bytes: serializedPubkey)
+		}
+	}
+}

--- a/Sources/BitcoinKit/Core/Keys/HDPrivateKey.swift
+++ b/Sources/BitcoinKit/Core/Keys/HDPrivateKey.swift
@@ -86,7 +86,7 @@ public class HDPrivateKey {
     }
 
     private func computePublicKeyData() -> Data {
-        return _Key.computePublicKey(fromPrivateKey: raw, compression: true)
+        return _SwiftKey.computePublicKey(fromPrivateKey: raw, compression: true)
     }
 
     public func derived(at index: UInt32, hardened: Bool = false) throws -> HDPrivateKey {

--- a/Sources/BitcoinKit/Core/Keys/PrivateKey.swift
+++ b/Sources/BitcoinKit/Core/Keys/PrivateKey.swift
@@ -120,7 +120,7 @@ public struct PrivateKey {
     }
 
     private func computePublicKeyData() -> Data {
-        return _Key.computePublicKey(fromPrivateKey: data, compression: isPublicKeyCompressed)
+        return _SwiftKey.computePublicKey(fromPrivateKey: data, compression: isPublicKeyCompressed)
     }
 
     public func publicKey() -> PublicKey {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

My motivation is a removal of the openssl library.
Using secp256k1 library which already in use is better than using openssl BIGNUM.
We can remove openssl library eventually.

### Alternate Designs

None.

### Benefits

see above.

### Possible Drawbacks

None.
All unit tests passed in iOS simulator.

### Applicable Issues

None.

