### PR TITLE
♻️ Refactor deprecated methods in Linux

### DIFF
--- a/Sources/BitcoinKitPrivate/BitcoinKit.Private.swift
+++ b/Sources/BitcoinKitPrivate/BitcoinKit.Private.swift
@@ -13,8 +13,10 @@ import secp256k1
 public class _Hash {
     public static func sha1(_ data: Data) -> Data {
         var result = [UInt8](repeating: 0, count: Int(SHA_DIGEST_LENGTH))
-        data.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            SHA1(ptr, data.count, &result)
+        data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            SHA1(ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                 data.count,
+                 &result)
             return
         }
         return Data(result)
@@ -22,16 +24,20 @@ public class _Hash {
     
     public static func sha256(_ data: Data) -> Data {
         var result = [UInt8](repeating: 0, count: Int(SHA256_DIGEST_LENGTH))
-        data.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            SHA256(ptr, data.count, &result)
+        data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            SHA256(ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                   data.count,
+                   &result)
             return
         }
         return Data(result)
     }
     public static func ripemd160(_ data: Data) -> Data {
         var result = [UInt8](repeating: 0, count: Int(RIPEMD160_DIGEST_LENGTH))
-        data.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            RIPEMD160(ptr, data.count, &result)
+        data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            RIPEMD160(ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                      data.count,
+                      &result)
             return
         }
         return Data(result)
@@ -45,10 +51,16 @@ public class _Hash {
         var length = UInt32(SHA512_DIGEST_LENGTH)
         var result = Data(count: Int(length))
         
-        data.withUnsafeBytes { (dataPtr: UnsafePointer<UInt8>) in
-            key.withUnsafeBytes { (keyPtr: UnsafePointer<UInt8>) in
-                result.withUnsafeMutableBytes { (resultPtr: UnsafeMutablePointer<UInt8>) in
-                    HMAC(EVP_sha512(), keyPtr, Int32(key.count), dataPtr, data.count, resultPtr, &length)
+        data.withUnsafeBytes { (dataPtr: UnsafeRawBufferPointer) in
+            key.withUnsafeBytes { (keyPtr: UnsafeRawBufferPointer) in
+                result.withUnsafeMutableBytes { (resultPtr: UnsafeMutableRawBufferPointer) in
+                    HMAC(EVP_sha512(),
+                         keyPtr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                         Int32(key.count),
+                         dataPtr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                         data.count,
+                         resultPtr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                         &length)
                     return
                 }
             }
@@ -75,8 +87,12 @@ public class _SwiftKey {
         defer {
             BN_free(prv)
         }
-        privateKey.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            BN_bin2bn(ptr, Int32(privateKey.count), prv)
+        privateKey.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            BN_bin2bn(
+                ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                Int32(privateKey.count),
+                prv
+            )
             return
         }
         
@@ -109,9 +125,17 @@ public class _SwiftKey {
 public class _Key {
     public static func deriveKey(_ password: Data, salt: Data, iterations:Int, keyLength: Int) -> Data {
         var result = [UInt8](repeating: 0, count: keyLength)
-        password.withUnsafeBytes { (passwordPtr: UnsafePointer<Int8>) in
-            salt.withUnsafeBytes { (saltPtr: UnsafePointer<UInt8>) in
-                PKCS5_PBKDF2_HMAC(passwordPtr, Int32(password.count), saltPtr, Int32(salt.count), Int32(iterations), EVP_sha512(), Int32(keyLength), &result)
+        password.withUnsafeBytes { (passwordPtr: UnsafeRawBufferPointer) in
+            salt.withUnsafeBytes { (saltPtr: UnsafeRawBufferPointer) in
+                PKCS5_PBKDF2_HMAC(
+                    passwordPtr.bindMemory(to: Int8.self).baseAddress.unsafelyUnwrapped,
+                    Int32(password.count),
+                    saltPtr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                    Int32(salt.count),
+                    Int32(iterations),
+                    EVP_sha512(),
+                    Int32(keyLength),
+                    &result)
                 return
             }
         }
@@ -171,8 +195,12 @@ public class _HDKey {
             BN_free(factor)
         }
 
-        derivedPrivateKey.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            BN_bin2bn(ptr, Int32(derivedPrivateKey.count), factor)
+        derivedPrivateKey.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            BN_bin2bn(
+                ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                Int32(derivedPrivateKey.count),
+                factor
+            )
             return
         }
         // Factor is too big, this derivation is invalid.
@@ -186,8 +214,12 @@ public class _HDKey {
             defer {
                 BN_free(privateKeyNum)
             }
-            privateKey.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-                BN_bin2bn(ptr, Int32(privateKey.count), privateKeyNum)
+            privateKey.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+                BN_bin2bn(
+                    ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                    Int32(privateKey.count),
+                    privateKeyNum
+                )
                 return
             }
             BN_mod_add(privateKeyNum, privateKeyNum, factor, curveOrder, ctx)
@@ -201,8 +233,11 @@ public class _HDKey {
             }
             let numBytes = ((BN_num_bits(privateKeyNum)+7)/8) // BN_num_bytes
             result = Data(count: Int(numBytes))
-            result.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
-                BN_bn2bin(privateKeyNum, ptr)
+            result.withUnsafeMutableBytes { (ptr: UnsafeMutableRawBufferPointer) in
+                BN_bn2bin(
+                    privateKeyNum,
+                    ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped
+                )
                 return
             }
             if result.count < 32 {
@@ -214,8 +249,12 @@ public class _HDKey {
                 BN_free(publicKeyNum)
             }
             
-            publicKey.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-                BN_bin2bn(ptr, Int32(publicKey.count), publicKeyNum)
+            publicKey.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+                BN_bin2bn(
+                    ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                    Int32(publicKey.count),
+                    publicKeyNum
+                )
                 return
             }
             let group = EC_GROUP_new_by_curve_name(NID_secp256k1)
@@ -237,15 +276,18 @@ public class _HDKey {
             }
             EC_POINT_point2bn(group, point, POINT_CONVERSION_COMPRESSED, n, ctx)
             result = Data(count: 33)
-            result.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
-                BN_bn2bin(n, ptr)
+            result.withUnsafeMutableBytes { (ptr: UnsafeMutableRawBufferPointer) in
+                BN_bn2bin(
+                    n,
+                    ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped
+                )
                 return
             }
         }
         
         let fingerprintData = _Hash.sha256ripemd160(publicKey)
-        let fingerprint = fingerprintData.withUnsafeBytes{ (p: UnsafePointer<UInt32>) in
-            p.pointee
+        let fingerprint = fingerprintData.withUnsafeBytes{ (ptr: UnsafeRawBufferPointer) in
+            ptr.load(as: UInt32.self)
         }
         return _HDKey(privateKey: result,
                       publicKey: result,
@@ -264,8 +306,17 @@ public class _Crypto {
         
         let signature = UnsafeMutablePointer<secp256k1_ecdsa_signature>.allocate(capacity: 1)
         defer { signature.deallocate() }
-        let status = data.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            privateKey.withUnsafeBytes { secp256k1_ecdsa_sign(ctx, signature, ptr, $0, nil, nil) }
+        let status = data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            privateKey.withUnsafeBytes {
+                secp256k1_ecdsa_sign(
+                    ctx,
+                    signature,
+                    ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                    $0.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                    nil,
+                    nil
+                )
+            }
         }
         guard status == 1 else { throw CryptoError.signFailed }
         
@@ -275,7 +326,13 @@ public class _Crypto {
         
         var length: size_t = 128
         var der = Data(count: length)
-        guard der.withUnsafeMutableBytes({ return secp256k1_ecdsa_signature_serialize_der(ctx, $0, &length, normalizedsig) }) == 1 else { throw CryptoError.noEnoughSpace }
+        guard der.withUnsafeMutableBytes({
+            return secp256k1_ecdsa_signature_serialize_der(
+                ctx,
+                $0.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                &length,
+                normalizedsig
+            ) }) == 1 else { throw CryptoError.noEnoughSpace }
         der.count = length
         
         return der
@@ -287,17 +344,35 @@ public class _Crypto {
         
         let signaturePointer = UnsafeMutablePointer<secp256k1_ecdsa_signature>.allocate(capacity: 1)
         defer { signaturePointer.deallocate() }
-        guard signature.withUnsafeBytes({ secp256k1_ecdsa_signature_parse_der(ctx, signaturePointer, $0, signature.count) }) == 1 else {
+        guard signature.withUnsafeBytes({
+            secp256k1_ecdsa_signature_parse_der(
+                ctx,
+                signaturePointer,
+                $0.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                signature.count
+            )
+        }) == 1 else {
             throw CryptoError.signatureParseFailed
         }
         
         let pubkeyPointer = UnsafeMutablePointer<secp256k1_pubkey>.allocate(capacity: 1)
         defer { pubkeyPointer.deallocate() }
-        guard publicKey.withUnsafeBytes({ secp256k1_ec_pubkey_parse(ctx, pubkeyPointer, $0, publicKey.count) }) == 1 else {
+        guard publicKey.withUnsafeBytes({
+            secp256k1_ec_pubkey_parse(
+                ctx,
+                pubkeyPointer,
+                $0.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                publicKey.count
+            ) }) == 1 else {
             throw CryptoError.publicKeyParseFailed
         }
         
-        guard message.withUnsafeBytes ({ secp256k1_ecdsa_verify(ctx, signaturePointer, $0, pubkeyPointer) }) == 1 else {
+        guard message.withUnsafeBytes ({
+            secp256k1_ecdsa_verify(
+                ctx,
+                signaturePointer,
+                $0.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                pubkeyPointer) }) == 1 else {
             return false
         }
         
@@ -321,22 +396,34 @@ public class _EllipticCurve {
         
         let multiplication_factor = BN_new()
         defer { BN_free(multiplication_factor) }
-        scalar.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            BN_bin2bn(ptr, Int32(scalar.count), multiplication_factor)
+        scalar.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            BN_bin2bn(
+                ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                Int32(scalar.count),
+                multiplication_factor
+            )
             return
         }
         
         let point_x = BN_new()
         defer { BN_free(point_x) }
-        ecPointX.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            BN_bin2bn(ptr, Int32(ecPointX.count), point_x)
+        ecPointX.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            BN_bin2bn(
+                ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                Int32(ecPointX.count),
+                point_x
+            )
             return
         }
 
         let point_y = BN_new();
         defer { BN_free(point_y) }
-        ecPointY.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            BN_bin2bn(ptr, Int32(ecPointY.count), point_y)
+        ecPointY.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            BN_bin2bn(
+                ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                Int32(ecPointY.count),
+                point_y
+            )
             return
         }
 
@@ -370,8 +457,14 @@ public class _EllipticCurve {
         let point = EC_POINT_new(group)
         defer { EC_POINT_free(point) }
         
-        publicKeyCompressed.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            EC_POINT_oct2point(group, point, ptr, Int(publicKeyCompressed.count), ctx)
+        publicKeyCompressed.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            EC_POINT_oct2point(
+                group,
+                point,
+                ptr.bindMemory(to: UInt8.self).baseAddress.unsafelyUnwrapped,
+                Int(publicKeyCompressed.count),
+                ctx
+            )
             return
         }
         


### PR DESCRIPTION
### Description of the Change
Refactor `withUnsafeBytes` and `withUnsafeMutableBytes` for Linux

### Benefits
Kill warnings.

### Possible Drawbacks
None. 