### PR TITLE
:pencil: Ignore WordList files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "**/WordList.swift"
+  - "**/WordList+*.swift"


### PR DESCRIPTION
### Description of the Change
Changed codecov.yml to ignore `WordList+*.swift` files.

### Benefits
Bring more accurate coverage.